### PR TITLE
Allow "comments" on file data update

### DIFF
--- a/app/controllers/docs.php
+++ b/app/controllers/docs.php
@@ -27,6 +27,7 @@ class docs extends Controller {
             $name = htmlspecialchars($_POST["name"]);
             $slug = htmlspecialchars(@$_POST["slug"] ?: "");
             $data = htmlspecialchars(@$_POST["data"] ?: "");
+            $comment = htmlspecialchars(@$_POST["comment"] ?: "");
             $version_id = @$_POST["version_id"] ?: 0;
 
             if ($slug && !$this->is_slug_valid($slug)) {
@@ -38,7 +39,7 @@ class docs extends Controller {
                 return "Cannot save. Someone else also edited the file";
             }
 
-            $save = $this->docs_model->update_file($file_id, $name, $slug, $data, $this->user);
+            $save = $this->docs_model->update_file($file_id, $name, $slug, $data, $this->user, $comment);
             if ($save === false) {
                 return "Could not save file";
             }

--- a/app/models/docs_model.php
+++ b/app/models/docs_model.php
@@ -34,7 +34,7 @@ class docs_model extends Model {
         return !$db_error;
     }
 
-    function update_file($file_id, $name, $slug, $data, $user) {
+    function update_file($file_id, $name, $slug, $data, $user, $comment = '') {
         if ($file_id === false) {
             return false;
         }
@@ -54,8 +54,8 @@ class docs_model extends Model {
         }
 
         if ($file_type != 'directory') {
-            $stmt = $this->DB->prepare("INSERT INTO `file_data` (`file_id`, `data`, `action`, `created_by`) VALUES (?, ?, 'edit', ?)");
-            if (!$stmt->bind_param("iss", $file_id, $data, $user)) {
+            $stmt = $this->DB->prepare("INSERT INTO `file_data` (`file_id`, `data`, `action`, `created_by`, `comment`) VALUES (?, ?, 'edit', ?, ?)");
+            if (!$stmt->bind_param("isss", $file_id, $data, $user, $comment)) {
                 $db_error = true;
             }
             if (!$stmt->execute()) {
@@ -330,7 +330,7 @@ class docs_model extends Model {
         if ($file_id === false) {
             return false;
         }
-        $stmt = $this->DB->prepare("SELECT `id`, `action`, `timestamp`, `created_by` FROM `file_data` WHERE `file_id`=? ORDER BY `id` DESC");
+        $stmt = $this->DB->prepare("SELECT `id`, `action`, `timestamp`, `created_by`, `comment` FROM `file_data` WHERE `file_id`=? ORDER BY `id` DESC");
         if (!$stmt->bind_param("i", $file_id)) {
             return false;
         }

--- a/app/views/file_edit.php
+++ b/app/views/file_edit.php
@@ -34,7 +34,10 @@
                 <div class="file_title_edit">
                     <label for="filename">Name: </label><input type="text" name="name" id="editname" value="<?= isset($unsaved) ? $unsaved["name"] : $name ?>" required />
                     <label for="slug">Slug: </label><input type="text" name="slug" id="editslug" value="<?= isset($unsaved) ? $unsaved["slug"] : $slug ?>" required />
-                    <input type="submit" class="btn btn-green" name="save" value="Save page"/>
+                </div>
+                <div class="file_title_edit">
+                    <label for="comment">Comment (optional): </label><input type="text" name="comment" id="comment">
+                    <input type="submit" class="btn btn-green pull-right" name="save" value="Save page"/>
                 </div>
                 <div id="orig_file">
                     <div id="orig_file_name" hidden><?= $name ?></div>

--- a/app/views/file_history.php
+++ b/app/views/file_history.php
@@ -84,6 +84,9 @@
                             <a href="?history&id=<?= $edit["id"] ?>">
                                 <i class="fa fa-history"></i>
                                 <?= $username ?><span style="color: #777"> <?= $action ?> on </span><?= $time ?>
+                                <?php if (!empty($edit['comment'])): ?>
+                                <span style="color: #777">(Comment: <em><?= $edit['comment'] ?></em>)</span>
+                                <?php endif; ?>
                             </a>
                         </li>
                 <?php

--- a/db/database.sql
+++ b/db/database.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS `file_data` (
   `data` blob NOT NULL,
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `created_by` varchar(255) NOT NULL,
+  `comment` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 

--- a/db/migrations/add_comment_to_file_data.sql
+++ b/db/migrations/add_comment_to_file_data.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `file_data` ADD `comment` VARCHAR(255) NULL DEFAULT NULL AFTER `created_by`;


### PR DESCRIPTION
Provide a field for file editors that lets them provide an optional
comment for an edit they're making. Show this comment in the file
history.

Resolves T37.
